### PR TITLE
Adds support for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ layer-profile:
       dataset: [the name of your dbt dataset]
       threads: [1 or more]
       keyfile: [/path/to/bigquery/keyfile.json]
+      layer_project: [the Layer project to use for model training (opt)]
+      layer_api_key: [the API Key to access your Layer account (opt)]
 ```
 
 Now, start making predictions directly in your dbt DAG:

--- a/common/adapter.py
+++ b/common/adapter.py
@@ -161,7 +161,7 @@ class LayerAdapter(BaseAdapter):  # pylint: disable=abstract-method
         def training_func() -> Any:
             return entrypoint_module.main(input_df)
 
-        model_decorator(target_node.name)(training_func)()  # pylint: disable=no-value-for-parameter
+        model_decorator(project_name)(training_func)()  # pylint: disable=no-value-for-parameter
         logger.debug("Trained model {}, in project {}", target_node.name, project_name)
 
         output_df = pd.DataFrame.from_records([[target_node.name]], columns=["name"])

--- a/common/adapter.py
+++ b/common/adapter.py
@@ -149,7 +149,7 @@ class LayerAdapter(BaseAdapter):  # pylint: disable=abstract-method
         # build the dataframe
         layer_api_key = self.config.credentials.layer_api_key
         if layer_api_key is None:
-            raise RuntimeException('Missing credentials: layer_api_key.')
+            raise RuntimeException("Missing credentials: layer_api_key.")
         layer.login_with_api_key(layer_api_key)
         project_name = self.config.credentials.layer_project
         logger.debug("Training model {}, in project {}", target_node.name, project_name)

--- a/common/adapter.py
+++ b/common/adapter.py
@@ -146,12 +146,15 @@ class LayerAdapter(BaseAdapter):  # pylint: disable=abstract-method
             input_df = raw_input_df[layer_sql_function.train_columns].reset_index(drop=True)
         logger.debug("Fetched input dataframe - {}", input_df.shape)
 
-        # build the dataframe
+        # login to Layer
         layer_api_key = self.config.credentials.layer_api_key
-        if layer_api_key is None:
-            raise RuntimeException("Missing credentials: layer_api_key.")
-        layer.login_with_api_key(layer_api_key)
-        project_name = self.config.credentials.layer_project
+        if layer_api_key is not None:
+            layer.login_with_api_key(layer_api_key)
+        else:
+            raise RuntimeException("Missing credentials: Please configure 'layer_api_key' in your 'profiles.yaml'")
+
+        # build the dataframe
+        project_name = self.get_project_name(target_node)
         logger.debug("Training model {}, in project {}", target_node.name, project_name)
         layer.init(project_name)
 
@@ -173,6 +176,11 @@ class LayerAdapter(BaseAdapter):  # pylint: disable=abstract-method
         )
         return response, table
 
+    def get_project_name(self, node: ManifestNode) -> str:
+        if self.config.credentials.layer_project is not None:
+            return self.config.credentials.layer_project
+        return node.fqn[0]
+
     @staticmethod
     def _get_layer_meta(node: ManifestNode) -> LayerMeta:
         return LayerMeta(**node.meta.get("layer", {}))
@@ -185,7 +193,7 @@ class LayerAdapter(BaseAdapter):  # pylint: disable=abstract-method
     ) -> Tuple[LayerAdapterResponse, agate.Table]:
         input_df = self._fetch_dataframe_by_sql(source_node, param.sql)
 
-        project_name = target_node.fqn[0]
+        project_name = self.get_project_name(target_node)
         model_name = target_node.fqn[1]
 
         from .automl import AutoML

--- a/common/adapter.py
+++ b/common/adapter.py
@@ -149,7 +149,7 @@ class LayerAdapter(BaseAdapter):  # pylint: disable=abstract-method
         # build the dataframe
         layer_api_key = self.config.credentials.layer_api_key
         if layer_api_key is None:
-            raise RuntimeException('Missing credentials: layer_api_key. See ')
+            raise RuntimeException('Missing credentials: layer_api_key.')
         layer.login_with_api_key(layer_api_key)
         project_name = self.config.credentials.layer_project
         logger.debug("Training model {}, in project {}", target_node.name, project_name)

--- a/common/adapter.py
+++ b/common/adapter.py
@@ -147,6 +147,10 @@ class LayerAdapter(BaseAdapter):  # pylint: disable=abstract-method
         logger.debug("Fetched input dataframe - {}", input_df.shape)
 
         # build the dataframe
+        layer_api_key = self.config.credentials.layer_api_key
+        if layer_api_key is None:
+            raise RuntimeException('Missing credentials: layer_api_key. See ')
+        layer.login_with_api_key(layer_api_key)
         project_name = self.config.credentials.layer_project
         logger.debug("Training model {}, in project {}", target_node.name, project_name)
         layer.init(project_name)

--- a/dbt/adapters/layer_bigquery/connections.py
+++ b/dbt/adapters/layer_bigquery/connections.py
@@ -13,6 +13,7 @@ class LayerBigQueryCredentials(BigQueryCredentials):
     layer_configfile: Optional[str] = None
     layer_configfile_json: Optional[Dict[str, Any]] = None
     layer_project: Optional[str] = None
+    layer_api_key: Optional[str] = None
 
     @property
     def type(self) -> str:


### PR DESCRIPTION
Adds support for specifying your Layer API key as part of the dbt .profile.
Internally, this key is used to login the user to their account, enabling the capability to publish model trains to their account.

Fixes LAY-3256