### PR TITLE
Add first party packages to isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,13 @@ test: $(INSTALL_STAMP) ## Run unit tests
 
 .PHONY: format
 format: $(INSTALL_STAMP) ## Apply formatters
-	$(POETRY) run isort --profile=black --lines-after-imports=2 .
+	$(POETRY) run isort .
 	$(POETRY) run black .
 
 
 .PHONY: lint
 lint: $(INSTALL_STAMP) ## Run all linters
-	$(POETRY) run isort --profile=black --lines-after-imports=2 --check-only .
+	$(POETRY) run isort --check-only .
 	$(POETRY) run black --check . --diff
 	$(POETRY) run flake8 .
 	$(POETRY) run pylint  --recursive yes .
@@ -46,7 +46,7 @@ else
 endif
 	$(POETRY) run python -c "import dbt"
 
-.PHONY: publish 
+.PHONY: publish
 publish: ## Publish to PyPi - should only run in CI
 	@test $${PATCH_VERSION?PATCH_VERSION expected}
 	@test $${PYPI_USER?PYPI_USER expected}
@@ -57,7 +57,7 @@ publish: ## Publish to PyPi - should only run in CI
 	$(POETRY) publish --build --username $(PYPI_USER) --password $(PYPI_PASSWORD)
 	$(POETRY) version $(CURRENT_VERSION)
 
-build: test 
+build: test
 	$(POETRY) build
 
 .PHONY: clean
@@ -82,4 +82,3 @@ help: ## Show this help message.
 	@echo 'targets:'
 	@grep -E '^[8+a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@echo
-	

--- a/common/adapter.py
+++ b/common/adapter.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Mapping, Optional, Tuple
 
 import agate  # type: ignore
 import cloudpickle  # type: ignore
-import layer
 import pandas as pd  # type: ignore
 from dbt.adapters.base.impl import BaseAdapter  # type: ignore
 from dbt.adapters.base.relation import BaseRelation  # type: ignore
@@ -18,6 +17,8 @@ from dbt.contracts.connection import AdapterResponse  # type: ignore
 from dbt.contracts.graph.manifest import Manifest, ManifestNode  # type: ignore
 from dbt.events import AdapterLogger  # type: ignore
 from dbt.exceptions import RuntimeException  # type: ignore
+
+import layer
 from layer.decorators import model as model_decorator
 
 from . import pandas_helper

--- a/common/automl.py
+++ b/common/automl.py
@@ -1,14 +1,15 @@
 from abc import abstractmethod
 from typing import Any, List
 
-import layer
 import pandas as pd  # type: ignore
-from layer.decorators import model as model_decorator
 from sklearn.ensemble import AdaBoostClassifier, RandomForestClassifier  # type: ignore
 from sklearn.linear_model import LinearRegression, RidgeClassifier  # type: ignore
 from sklearn.metrics import r2_score, roc_auc_score  # type: ignore
 from sklearn.model_selection import train_test_split  # type: ignore
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor  # type: ignore
+
+import layer
+from layer.decorators import model as model_decorator
 
 
 class AutoMLModel:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,3 +263,8 @@ enable = [
     "deprecated-pragma",
     "invalid-name"
 ]
+
+[tool.isort]
+profile = "black"
+lines_after_imports = 2
+known_first_party = ["layer", "test"]


### PR DESCRIPTION
Add `layer` and `test` as first party packages to `isort` to sort imports correctly.