### PR TITLE
Fix help REGEX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,5 +84,5 @@ help: ## Show this help message.
 	@echo 'usage: make [target]'
 	@echo
 	@echo 'targets:'
-	@grep -E '^[8+a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[8+0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@echo


### PR DESCRIPTION
The `make` target (or `make help`) was not showing the `e2e-tests` target.
The regex used to filter out the target entries did not support numerical characters in the target name.
Before:
```
$make
usage: make [target]

targets:
install                        Install dependencies
test                           Run unit tests
int-test                       Run e2e tests
format                         Apply formatters
lint                           Run all linters
check                          Run test and lint
check-package-loads            Check that we can load the package without the dev dependencies
publish                        Publish to PyPi - should only run in CI
clean                          Resets development environment.
help                           Show this help message.
```
After
```
$make
usage: make [target]

targets:
install                        Install dependencies
test                           Run unit tests
e2e-test                       Run e2e tests
format                         Apply formatters
lint                           Run all linters
check                          Run test and lint
check-package-loads            Check that we can load the package without the dev dependencies
publish                        Publish to PyPi - should only run in CI
clean                          Resets development environment.
help                           Show this help message.
```
